### PR TITLE
Add custom directory migration and safer rollback

### DIFF
--- a/AppPorts/ContentView.swift
+++ b/AppPorts/ContentView.swift
@@ -263,7 +263,7 @@ struct ContentView: View {
     @State private var sortOption: SortOption = .name
 
     // MARK: - Tab
-    enum MainTab { case apps, dataDirs }
+    enum MainTab { case apps, dataDirs, customDirs }
     @State private var mainTab: MainTab = .apps
     @State private var selectedDataDirsTab: DataDirsView.DataTab = .toolDirs
     @State private var selectedDataDirsApp: AppItem? = nil
@@ -282,6 +282,9 @@ struct ContentView: View {
                     }
                     TabButton(title: "数据目录", systemImage: "cylinder", isSelected: mainTab == .dataDirs) {
                         withAnimation { mainTab = .dataDirs }
+                    }
+                    TabButton(title: "目录迁移", systemImage: "folder.badge.gearshape", isSelected: mainTab == .customDirs) {
+                        withAnimation { mainTab = .customDirs }
                     }
                 }
                 .padding(3)
@@ -397,6 +400,8 @@ struct ContentView: View {
                         performBackupSignature(at: url, bundleID: getBundleIdentifier(from: url))
                     }
                 )
+            } else if mainTab == .customDirs {
+                CustomDirsView()
             } else {
 
             HSplitView {
@@ -830,7 +835,7 @@ struct ContentView: View {
         let icon: String
         var actionButtonText: String? = nil
         var onAction: (() -> Void)? = nil
-        let onRefresh: () -> Void
+        var onRefresh: (() -> Void)? = nil
         
         var body: some View {
             VStack(spacing: 0) {
@@ -861,12 +866,14 @@ struct ContentView: View {
                             .buttonStyle(.bordered)
                     }
                     
-                    Button(action: onRefresh) {
-                        Image(systemName: "arrow.clockwise")
+                    if let onRefresh {
+                        Button(action: onRefresh) {
+                            Image(systemName: "arrow.clockwise")
+                        }
+                        .buttonStyle(.borderless)
+                        .padding(.leading, 8)
+                        .help("刷新列表".localized)
                     }
-                    .buttonStyle(.borderless)
-                    .padding(.leading, 8)
-                    .help("刷新列表".localized)
                 }
                 .padding(.horizontal, 20)
                 .padding(.vertical, 16)

--- a/AppPorts/Localizable.xcstrings
+++ b/AppPorts/Localizable.xcstrings
@@ -1,6 +1,5718 @@
 {
   "sourceLanguage" : "zh-Hans",
   "strings" : {
+    "正在迁移目录" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrating folders"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrating folders"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrating folders"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrating folders"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrating folders"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrating folders"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrating folders"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrating folders"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrating folders"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrating folders"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrating folders"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrating folders"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrating folders"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrating folders"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrating folders"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrating folders"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrating folders"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrating folders"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrating folders"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在迁移目录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在遷移目錄"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在迁移目录"
+          }
+        }
+      }
+    },
+    "正在接回目录" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relinking folders"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relinking folders"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relinking folders"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relinking folders"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relinking folders"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relinking folders"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relinking folders"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relinking folders"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relinking folders"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relinking folders"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relinking folders"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relinking folders"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relinking folders"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relinking folders"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relinking folders"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relinking folders"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relinking folders"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relinking folders"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relinking folders"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在接回目录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在接回目錄"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在接回目录"
+          }
+        }
+      }
+    },
+    "正在还原目录" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring folders"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring folders"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring folders"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring folders"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring folders"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring folders"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring folders"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring folders"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring folders"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring folders"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring folders"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring folders"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring folders"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring folders"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring folders"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring folders"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring folders"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring folders"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring folders"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在还原目录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在還原目錄"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在还原目录"
+          }
+        }
+      }
+    },
+    "添加目录迁移" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Directory Migration"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Directory Migration"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Directory Migration"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Directory Migration"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Directory Migration"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Directory Migration"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Directory Migration"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Directory Migration"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Directory Migration"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Directory Migration"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Directory Migration"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Directory Migration"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Directory Migration"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Directory Migration"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Directory Migration"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Directory Migration"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Directory Migration"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Directory Migration"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Directory Migration"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加目录迁移"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加目錄遷移"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加目录迁移"
+          }
+        }
+      }
+    },
+    "本地目录 - 只支持迁移用户目录下的文件夹" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder - only folders inside the user folder can be migrated"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder - only folders inside the user folder can be migrated"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder - only folders inside the user folder can be migrated"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder - only folders inside the user folder can be migrated"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder - only folders inside the user folder can be migrated"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder - only folders inside the user folder can be migrated"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder - only folders inside the user folder can be migrated"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder - only folders inside the user folder can be migrated"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder - only folders inside the user folder can be migrated"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder - only folders inside the user folder can be migrated"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder - only folders inside the user folder can be migrated"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder - only folders inside the user folder can be migrated"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder - only folders inside the user folder can be migrated"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder - only folders inside the user folder can be migrated"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder - only folders inside the user folder can be migrated"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder - only folders inside the user folder can be migrated"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder - only folders inside the user folder can be migrated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder - only folders inside the user folder can be migrated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder - only folders inside the user folder can be migrated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地目录 - 只支持迁移用户目录下的文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本機目錄 - 僅支援遷移用戶目錄下的資料夾"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地目录 - 只支持迁移用户目录下的文件夹"
+          }
+        }
+      }
+    },
+    "本地目录必须位于当前用户目录下" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder must be inside the current user folder"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder must be inside the current user folder"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder must be inside the current user folder"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder must be inside the current user folder"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder must be inside the current user folder"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder must be inside the current user folder"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder must be inside the current user folder"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder must be inside the current user folder"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder must be inside the current user folder"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder must be inside the current user folder"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder must be inside the current user folder"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder must be inside the current user folder"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder must be inside the current user folder"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder must be inside the current user folder"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder must be inside the current user folder"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder must be inside the current user folder"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder must be inside the current user folder"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder must be inside the current user folder"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder must be inside the current user folder"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地目录必须位于当前用户目录下"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本機目錄必須位於目前用戶目錄下"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地目录必须位于当前用户目录下"
+          }
+        }
+      }
+    },
+    "不能迁移整个用户目录" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The entire user folder cannot be migrated"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The entire user folder cannot be migrated"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The entire user folder cannot be migrated"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The entire user folder cannot be migrated"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The entire user folder cannot be migrated"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The entire user folder cannot be migrated"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The entire user folder cannot be migrated"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The entire user folder cannot be migrated"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The entire user folder cannot be migrated"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The entire user folder cannot be migrated"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The entire user folder cannot be migrated"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The entire user folder cannot be migrated"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The entire user folder cannot be migrated"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The entire user folder cannot be migrated"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The entire user folder cannot be migrated"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The entire user folder cannot be migrated"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The entire user folder cannot be migrated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The entire user folder cannot be migrated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The entire user folder cannot be migrated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不能迁移整个用户目录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不能遷移整個用戶目錄"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不能迁移整个用户目录"
+          }
+        }
+      }
+    },
+    "不能迁移软链接目录，请选择真实文件夹" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbolic link folders cannot be migrated. Choose a real folder."
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbolic link folders cannot be migrated. Choose a real folder."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbolic link folders cannot be migrated. Choose a real folder."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbolic link folders cannot be migrated. Choose a real folder."
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbolic link folders cannot be migrated. Choose a real folder."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbolic link folders cannot be migrated. Choose a real folder."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbolic link folders cannot be migrated. Choose a real folder."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbolic link folders cannot be migrated. Choose a real folder."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbolic link folders cannot be migrated. Choose a real folder."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbolic link folders cannot be migrated. Choose a real folder."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbolic link folders cannot be migrated. Choose a real folder."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbolic link folders cannot be migrated. Choose a real folder."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbolic link folders cannot be migrated. Choose a real folder."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbolic link folders cannot be migrated. Choose a real folder."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbolic link folders cannot be migrated. Choose a real folder."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbolic link folders cannot be migrated. Choose a real folder."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbolic link folders cannot be migrated. Choose a real folder."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbolic link folders cannot be migrated. Choose a real folder."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbolic link folders cannot be migrated. Choose a real folder."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不能迁移软链接目录，请选择真实文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不能遷移軟連結目錄，請選擇真實資料夾"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不能迁移软链接目录，请选择真实文件夹"
+          }
+        }
+      }
+    },
+    "该目录与已管理目录存在包含关系" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder overlaps with a managed folder"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder overlaps with a managed folder"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder overlaps with a managed folder"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder overlaps with a managed folder"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder overlaps with a managed folder"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder overlaps with a managed folder"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder overlaps with a managed folder"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder overlaps with a managed folder"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder overlaps with a managed folder"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder overlaps with a managed folder"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder overlaps with a managed folder"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder overlaps with a managed folder"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder overlaps with a managed folder"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder overlaps with a managed folder"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder overlaps with a managed folder"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder overlaps with a managed folder"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder overlaps with a managed folder"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder overlaps with a managed folder"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder overlaps with a managed folder"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该目录与已管理目录存在包含关系"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該目錄與已管理目錄存在包含關係"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该目录与已管理目录存在包含关系"
+          }
+        }
+      }
+    },
+    "外部目标不能位于当前用户目录内" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target cannot be inside the current user folder"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target cannot be inside the current user folder"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target cannot be inside the current user folder"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target cannot be inside the current user folder"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target cannot be inside the current user folder"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target cannot be inside the current user folder"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target cannot be inside the current user folder"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target cannot be inside the current user folder"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target cannot be inside the current user folder"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target cannot be inside the current user folder"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target cannot be inside the current user folder"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target cannot be inside the current user folder"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target cannot be inside the current user folder"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target cannot be inside the current user folder"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target cannot be inside the current user folder"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target cannot be inside the current user folder"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target cannot be inside the current user folder"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target cannot be inside the current user folder"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target cannot be inside the current user folder"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部目标不能位于当前用户目录内"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部目標不能位於目前用戶目錄內"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部目标不能位于当前用户目录内"
+          }
+        }
+      }
+    },
+    "外部目标与已管理目录存在包含关系" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target overlaps with a managed folder"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target overlaps with a managed folder"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target overlaps with a managed folder"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target overlaps with a managed folder"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target overlaps with a managed folder"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target overlaps with a managed folder"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target overlaps with a managed folder"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target overlaps with a managed folder"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target overlaps with a managed folder"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target overlaps with a managed folder"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target overlaps with a managed folder"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target overlaps with a managed folder"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target overlaps with a managed folder"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target overlaps with a managed folder"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target overlaps with a managed folder"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target overlaps with a managed folder"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target overlaps with a managed folder"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target overlaps with a managed folder"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external target overlaps with a managed folder"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部目标与已管理目录存在包含关系"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部目標與已管理目錄存在包含關係"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部目标与已管理目录存在包含关系"
+          }
+        }
+      }
+    },
+    "断开链接" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Link"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Link"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Link"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Link"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Link"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Link"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Link"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Link"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Link"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Link"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Link"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Link"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Link"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Link"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Link"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Link"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Link"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Link"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Link"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "断开链接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中斷連結"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "断开链接"
+          }
+        }
+      }
+    },
+    "断开此链接并保留外部文件夹" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect this link and keep the external folder"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect this link and keep the external folder"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect this link and keep the external folder"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect this link and keep the external folder"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect this link and keep the external folder"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect this link and keep the external folder"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect this link and keep the external folder"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect this link and keep the external folder"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect this link and keep the external folder"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect this link and keep the external folder"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect this link and keep the external folder"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect this link and keep the external folder"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect this link and keep the external folder"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect this link and keep the external folder"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect this link and keep the external folder"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect this link and keep the external folder"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect this link and keep the external folder"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect this link and keep the external folder"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect this link and keep the external folder"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "断开此链接并保留外部文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中斷此連結並保留外部資料夾"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "断开此链接并保留外部文件夹"
+          }
+        }
+      }
+    },
+    "目录迁移" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directory Migration"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directory Migration"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directory Migration"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directory Migration"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directory Migration"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directory Migration"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directory Migration"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directory Migration"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directory Migration"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directory Migration"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directory Migration"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directory Migration"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directory Migration"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directory Migration"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directory Migration"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directory Migration"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directory Migration"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directory Migration"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directory Migration"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目录迁移"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目錄遷移"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目录迁移"
+          }
+        }
+      }
+    },
+    "本地文件夹" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folders"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folders"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folders"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folders"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folders"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folders"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folders"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folders"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folders"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folders"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folders"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folders"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folders"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folders"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folders"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folders"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folders"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folders"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folders"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地資料夾"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地文件夹"
+          }
+        }
+      }
+    },
+    "外部文件夹" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Folders"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Folders"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Folders"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Folders"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Folders"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Folders"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Folders"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Folders"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Folders"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Folders"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Folders"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Folders"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Folders"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Folders"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Folders"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Folders"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Folders"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Folders"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Folders"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部資料夾"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部文件夹"
+          }
+        }
+      }
+    },
+    "移除记录" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Record"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Record"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Record"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Record"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Record"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Record"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Record"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Record"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Record"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Record"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Record"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Record"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Record"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Record"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Record"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Record"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Record"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Record"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Record"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除记录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除記錄"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除记录"
+          }
+        }
+      }
+    },
+    "未添加目录迁移" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No directory migrations added"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No directory migrations added"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No directory migrations added"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No directory migrations added"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No directory migrations added"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No directory migrations added"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No directory migrations added"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No directory migrations added"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No directory migrations added"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No directory migrations added"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No directory migrations added"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No directory migrations added"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No directory migrations added"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No directory migrations added"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No directory migrations added"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No directory migrations added"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No directory migrations added"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No directory migrations added"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No directory migrations added"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未添加目录迁移"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚未新增目錄遷移"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未添加目录迁移"
+          }
+        }
+      }
+    },
+    "%lld 个目标文件夹" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld destination folders"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld destination folders"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld destination folders"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld destination folders"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld destination folders"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld destination folders"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld destination folders"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld destination folders"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld destination folders"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld destination folders"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld destination folders"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld destination folders"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld destination folders"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld destination folders"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld destination folders"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld destination folders"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld destination folders"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld destination folders"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld destination folders"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 个目标文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 個目標資料夾"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 个目标文件夹"
+          }
+        }
+      }
+    },
+    "迁移文件夹" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate Folders"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate Folders"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate Folders"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate Folders"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate Folders"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate Folders"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate Folders"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate Folders"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate Folders"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate Folders"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate Folders"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate Folders"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate Folders"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate Folders"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate Folders"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate Folders"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate Folders"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate Folders"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate Folders"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "迁移文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "遷移資料夾"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "迁移文件夹"
+          }
+        }
+      }
+    },
+    "迁移 %lld 个文件夹" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate %lld Folders"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate %lld Folders"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate %lld Folders"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate %lld Folders"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate %lld Folders"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate %lld Folders"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate %lld Folders"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate %lld Folders"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate %lld Folders"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate %lld Folders"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate %lld Folders"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate %lld Folders"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate %lld Folders"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate %lld Folders"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate %lld Folders"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate %lld Folders"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate %lld Folders"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate %lld Folders"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate %lld Folders"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "迁移 %lld 个文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "遷移 %lld 個資料夾"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "迁移 %lld 个文件夹"
+          }
+        }
+      }
+    },
+    "接回文件夹" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink Folders"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink Folders"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink Folders"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink Folders"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink Folders"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink Folders"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink Folders"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink Folders"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink Folders"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink Folders"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink Folders"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink Folders"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink Folders"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink Folders"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink Folders"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink Folders"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink Folders"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink Folders"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink Folders"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接回文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接回資料夾"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接回文件夹"
+          }
+        }
+      }
+    },
+    "接回 %lld 个文件夹" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink %lld Folders"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink %lld Folders"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink %lld Folders"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink %lld Folders"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink %lld Folders"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink %lld Folders"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink %lld Folders"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink %lld Folders"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink %lld Folders"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink %lld Folders"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink %lld Folders"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink %lld Folders"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink %lld Folders"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink %lld Folders"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink %lld Folders"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink %lld Folders"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink %lld Folders"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink %lld Folders"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relink %lld Folders"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接回 %lld 个文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接回 %lld 個資料夾"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接回 %lld 个文件夹"
+          }
+        }
+      }
+    },
+    "还原文件夹" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Folders"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Folders"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Folders"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Folders"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Folders"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Folders"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Folders"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Folders"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Folders"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Folders"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Folders"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Folders"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Folders"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Folders"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Folders"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Folders"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Folders"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Folders"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Folders"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "还原文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "還原資料夾"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "还原文件夹"
+          }
+        }
+      }
+    },
+    "还原 %lld 个文件夹" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore %lld Folders"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore %lld Folders"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore %lld Folders"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore %lld Folders"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore %lld Folders"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore %lld Folders"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore %lld Folders"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore %lld Folders"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore %lld Folders"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore %lld Folders"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore %lld Folders"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore %lld Folders"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore %lld Folders"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore %lld Folders"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore %lld Folders"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore %lld Folders"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore %lld Folders"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore %lld Folders"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore %lld Folders"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "还原 %lld 个文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "還原 %lld 個資料夾"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "还原 %lld 个文件夹"
+          }
+        }
+      }
+    },
+    "该目录已在目录迁移列表中" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder is already in the directory migration list"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder is already in the directory migration list"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder is already in the directory migration list"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder is already in the directory migration list"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder is already in the directory migration list"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder is already in the directory migration list"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder is already in the directory migration list"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder is already in the directory migration list"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder is already in the directory migration list"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder is already in the directory migration list"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder is already in the directory migration list"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder is already in the directory migration list"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder is already in the directory migration list"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder is already in the directory migration list"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder is already in the directory migration list"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder is already in the directory migration list"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder is already in the directory migration list"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder is already in the directory migration list"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This folder is already in the directory migration list"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该目录已在目录迁移列表中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該目錄已在目錄遷移列表中"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该目录已在目录迁移列表中"
+          }
+        }
+      }
+    },
+    "本地目录" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Folder"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地目录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地目錄"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地目录"
+          }
+        }
+      }
+    },
+    "选择本地目录" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Local Folder"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Local Folder"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Local Folder"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Local Folder"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Local Folder"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Local Folder"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Local Folder"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Local Folder"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Local Folder"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Local Folder"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Local Folder"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Local Folder"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Local Folder"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Local Folder"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Local Folder"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Local Folder"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Local Folder"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Local Folder"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Local Folder"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择本地目录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇本地目錄"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择本地目录"
+          }
+        }
+      }
+    },
+    "外部目标文件夹" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Destination Folder"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Destination Folder"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Destination Folder"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Destination Folder"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Destination Folder"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Destination Folder"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Destination Folder"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Destination Folder"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Destination Folder"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Destination Folder"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Destination Folder"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Destination Folder"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Destination Folder"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Destination Folder"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Destination Folder"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Destination Folder"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Destination Folder"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Destination Folder"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Destination Folder"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部目标文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部目標資料夾"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部目标文件夹"
+          }
+        }
+      }
+    },
+    "选择外部目标文件夹" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose External Destination Folder"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose External Destination Folder"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose External Destination Folder"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose External Destination Folder"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose External Destination Folder"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose External Destination Folder"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose External Destination Folder"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose External Destination Folder"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose External Destination Folder"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose External Destination Folder"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose External Destination Folder"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose External Destination Folder"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose External Destination Folder"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose External Destination Folder"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose External Destination Folder"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose External Destination Folder"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose External Destination Folder"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose External Destination Folder"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose External Destination Folder"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择外部目标文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇外部目標資料夾"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择外部目标文件夹"
+          }
+        }
+      }
+    },
+    "最终位置" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Final Location"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Final Location"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Final Location"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Final Location"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Final Location"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Final Location"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Final Location"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Final Location"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Final Location"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Final Location"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Final Location"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Final Location"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Final Location"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Final Location"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Final Location"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Final Location"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Final Location"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Final Location"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Final Location"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最终位置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最終位置"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最终位置"
+          }
+        }
+      }
+    },
+    "添加" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加"
+          }
+        }
+      }
+    },
+    "选择要迁移的本地文件夹" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the local folder to migrate"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the local folder to migrate"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the local folder to migrate"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the local folder to migrate"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the local folder to migrate"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the local folder to migrate"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the local folder to migrate"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the local folder to migrate"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the local folder to migrate"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the local folder to migrate"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the local folder to migrate"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the local folder to migrate"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the local folder to migrate"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the local folder to migrate"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the local folder to migrate"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the local folder to migrate"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the local folder to migrate"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the local folder to migrate"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the local folder to migrate"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择要迁移的本地文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇要遷移的本地資料夾"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择要迁移的本地文件夹"
+          }
+        }
+      }
+    },
+    "选择外部目标父文件夹" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the external destination parent folder"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the external destination parent folder"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the external destination parent folder"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the external destination parent folder"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the external destination parent folder"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the external destination parent folder"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the external destination parent folder"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the external destination parent folder"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the external destination parent folder"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the external destination parent folder"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the external destination parent folder"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the external destination parent folder"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the external destination parent folder"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the external destination parent folder"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the external destination parent folder"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the external destination parent folder"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the external destination parent folder"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the external destination parent folder"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the external destination parent folder"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择外部目标父文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇外部目標父資料夾"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择外部目标父文件夹"
+          }
+        }
+      }
+    },
+    "请选择本地目录和外部目标文件夹" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose both a local folder and an external destination folder"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose both a local folder and an external destination folder"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose both a local folder and an external destination folder"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose both a local folder and an external destination folder"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose both a local folder and an external destination folder"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose both a local folder and an external destination folder"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose both a local folder and an external destination folder"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose both a local folder and an external destination folder"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose both a local folder and an external destination folder"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose both a local folder and an external destination folder"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose both a local folder and an external destination folder"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose both a local folder and an external destination folder"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose both a local folder and an external destination folder"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose both a local folder and an external destination folder"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose both a local folder and an external destination folder"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose both a local folder and an external destination folder"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose both a local folder and an external destination folder"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose both a local folder and an external destination folder"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose both a local folder and an external destination folder"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请选择本地目录和外部目标文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請選擇本地目錄和外部目標資料夾"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请选择本地目录和外部目标文件夹"
+          }
+        }
+      }
+    },
+    "本地目录不存在或不是文件夹" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local path does not exist or is not a folder"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local path does not exist or is not a folder"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local path does not exist or is not a folder"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local path does not exist or is not a folder"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local path does not exist or is not a folder"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local path does not exist or is not a folder"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local path does not exist or is not a folder"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local path does not exist or is not a folder"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local path does not exist or is not a folder"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local path does not exist or is not a folder"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local path does not exist or is not a folder"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local path does not exist or is not a folder"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local path does not exist or is not a folder"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local path does not exist or is not a folder"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local path does not exist or is not a folder"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local path does not exist or is not a folder"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local path does not exist or is not a folder"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local path does not exist or is not a folder"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local path does not exist or is not a folder"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地目录不存在或不是文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地目錄不存在或不是資料夾"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地目录不存在或不是文件夹"
+          }
+        }
+      }
+    },
+    "外部目标不是文件夹" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination is not a folder"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination is not a folder"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination is not a folder"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination is not a folder"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination is not a folder"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination is not a folder"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination is not a folder"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination is not a folder"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination is not a folder"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination is not a folder"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination is not a folder"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination is not a folder"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination is not a folder"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination is not a folder"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination is not a folder"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination is not a folder"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination is not a folder"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination is not a folder"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination is not a folder"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部目标不是文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部目標不是資料夾"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部目标不是文件夹"
+          }
+        }
+      }
+    },
+    "该路径不适合作为目录迁移来源" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration source"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration source"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration source"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration source"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration source"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration source"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration source"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration source"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration source"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration source"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration source"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration source"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration source"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration source"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration source"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration source"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration source"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration source"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration source"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该路径不适合作为目录迁移来源"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該路徑不適合作為目錄遷移來源"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该路径不适合作为目录迁移来源"
+          }
+        }
+      }
+    },
+    "该路径不适合作为目录迁移目标" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration target"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration target"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration target"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration target"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration target"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration target"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration target"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration target"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration target"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration target"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration target"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration target"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration target"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration target"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration target"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration target"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration target"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration target"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This path is not suitable as a directory migration target"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该路径不适合作为目录迁移目标"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該路徑不適合作為目錄遷移目標"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该路径不适合作为目录迁移目标"
+          }
+        }
+      }
+    },
+    "外部目标不能位于本地目录内部" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination cannot be inside the local folder"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination cannot be inside the local folder"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination cannot be inside the local folder"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination cannot be inside the local folder"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination cannot be inside the local folder"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination cannot be inside the local folder"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination cannot be inside the local folder"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination cannot be inside the local folder"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination cannot be inside the local folder"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination cannot be inside the local folder"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination cannot be inside the local folder"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination cannot be inside the local folder"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination cannot be inside the local folder"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination cannot be inside the local folder"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination cannot be inside the local folder"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination cannot be inside the local folder"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination cannot be inside the local folder"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination cannot be inside the local folder"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The external destination cannot be inside the local folder"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部目标不能位于本地目录内部"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部目標不能位於本地目錄內部"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部目标不能位于本地目录内部"
+          }
+        }
+      }
+    },
+    "本地目录不能位于外部目标内部" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder cannot be inside the external destination"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder cannot be inside the external destination"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder cannot be inside the external destination"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder cannot be inside the external destination"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder cannot be inside the external destination"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder cannot be inside the external destination"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder cannot be inside the external destination"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder cannot be inside the external destination"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder cannot be inside the external destination"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder cannot be inside the external destination"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder cannot be inside the external destination"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder cannot be inside the external destination"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder cannot be inside the external destination"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder cannot be inside the external destination"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder cannot be inside the external destination"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder cannot be inside the external destination"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder cannot be inside the external destination"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder cannot be inside the external destination"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The local folder cannot be inside the external destination"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地目录不能位于外部目标内部"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地目錄不能位於外部目標內部"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地目录不能位于外部目标内部"
+          }
+        }
+      }
+    },
+    "目标冲突" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination Conflict"
+          }
+        },
+        "br" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination Conflict"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination Conflict"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination Conflict"
+          }
+        },
+        "eo" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination Conflict"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination Conflict"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination Conflict"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination Conflict"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination Conflict"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination Conflict"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination Conflict"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination Conflict"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination Conflict"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination Conflict"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination Conflict"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination Conflict"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination Conflict"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination Conflict"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination Conflict"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目标冲突"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目標衝突"
+          }
+        },
+        "zh-martian" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目标冲突"
+          }
+        }
+      }
+    },
     "" : {
       "localizations" : {
         "ar" : {

--- a/AppPorts/Localizable.xcstrings
+++ b/AppPorts/Localizable.xcstrings
@@ -72421,115 +72421,115 @@
         }
       }
     },
-    "正在删除原目录..." : {
+    "正在切换本地入口..." : {
       "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deleting original directory..."
+            "value" : "Switching local entry..."
           }
         },
         "br" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "⠠⠙⠑⠇⠑⠞⠊⠝⠛ ⠕⠗⠊⠛⠊⠝⠁⠇ ⠙⠊⠗⠑⠉⠞⠕⠗⠽⠲⠲⠲"
+            "value" : "Switching local entry..."
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deleting original directory..."
+            "value" : "Switching local entry..."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deleting original directory..."
+            "value" : "Switching local entry..."
           }
         },
         "eo" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deleting original directory..."
+            "value" : "Switching local entry..."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deleting original directory..."
+            "value" : "Switching local entry..."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deleting original directory..."
+            "value" : "Switching local entry..."
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deleting original directory..."
+            "value" : "Switching local entry..."
           }
         },
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deleting original directory..."
+            "value" : "Switching local entry..."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deleting original directory..."
+            "value" : "Switching local entry..."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deleting original directory..."
+            "value" : "Switching local entry..."
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deleting original directory..."
+            "value" : "Switching local entry..."
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deleting original directory..."
+            "value" : "Switching local entry..."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deleting original directory..."
+            "value" : "Switching local entry..."
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deleting original directory..."
+            "value" : "Switching local entry..."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deleting original directory..."
+            "value" : "Switching local entry..."
           }
         },
         "th" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deleting original directory..."
+            "value" : "Switching local entry..."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deleting original directory..."
+            "value" : "Switching local entry..."
           }
         },
         "vi" : {
@@ -72541,19 +72541,19 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在删除原目录..."
+            "value" : "正在切换本地入口..."
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在删除原目錄..."
+            "value" : "正在切換本地入口..."
           }
         },
         "zh-martian" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在删除原目录..."
+            "value" : "正在切换本地入口..."
           }
         }
       }

--- a/AppPorts/Models/CustomDirModels.swift
+++ b/AppPorts/Models/CustomDirModels.swift
@@ -1,0 +1,370 @@
+//
+//  CustomDirModels.swift
+//  AppPorts
+//
+//  Created by Codex on 2026/6/26.
+//
+
+import Foundation
+
+enum CustomDirStatus {
+    static let local = "本地"
+    static let linked = "已链接"
+    static let orphanedLink = "孤立链接"
+    static let pendingRelink = "待接回"
+    static let missing = "未找到"
+    static let external = "外部"
+    static let destinationConflict = "目标冲突"
+}
+
+struct CustomDirConfig: Identifiable, Codable, Equatable, Sendable {
+    var id: UUID
+    var localPath: String
+    var externalBasePath: String
+    var createdAt: Date
+
+    init(
+        id: UUID = UUID(),
+        localPath: String,
+        externalBasePath: String,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.localPath = localPath
+        self.externalBasePath = externalBasePath
+        self.createdAt = createdAt
+    }
+
+    nonisolated var localURL: URL {
+        URL(fileURLWithPath: localPath).standardizedFileURL
+    }
+
+    nonisolated var externalBaseURL: URL {
+        URL(fileURLWithPath: externalBasePath).standardizedFileURL
+    }
+
+    nonisolated var externalDestinationURL: URL {
+        externalBaseURL.appendingPathComponent(localURL.lastPathComponent).standardizedFileURL
+    }
+
+    nonisolated var displayName: String {
+        localURL.lastPathComponent
+    }
+}
+
+enum CustomDirValidationError: LocalizedError, Equatable {
+    case localNotDirectory
+    case externalNotDirectory
+    case localOutsideHome
+    case localIsHome
+    case localIsSymlink
+    case localOverlapsManagedDirectory
+    case externalInsideLocal
+    case localInsideExternal
+    case externalInsideHome
+    case externalOverlapsManagedDirectory
+
+    var errorDescription: String? {
+        switch self {
+        case .localNotDirectory:
+            return "本地目录不存在或不是文件夹".localized
+        case .externalNotDirectory:
+            return "外部目标不是文件夹".localized
+        case .externalInsideLocal:
+            return "外部目标不能位于本地目录内部".localized
+        case .localInsideExternal:
+            return "本地目录不能位于外部目标内部".localized
+        case .localOutsideHome:
+            return "本地目录必须位于当前用户目录下".localized
+        case .localIsHome:
+            return "不能迁移整个用户目录".localized
+        case .localIsSymlink:
+            return "不能迁移软链接目录，请选择真实文件夹".localized
+        case .localOverlapsManagedDirectory:
+            return "该目录与已管理目录存在包含关系".localized
+        case .externalInsideHome:
+            return "外部目标不能位于当前用户目录内".localized
+        case .externalOverlapsManagedDirectory:
+            return "外部目标与已管理目录存在包含关系".localized
+        }
+    }
+}
+
+enum CustomDirValidator {
+    static func validateLocalDirectory(
+        _ localURL: URL,
+        existingConfigs: [CustomDirConfig],
+        homeURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default
+    ) throws {
+        let homeURL = homeURL.standardizedFileURL
+        let localPath = normalizedPath(localURL)
+        let homePath = normalizedPath(homeURL)
+
+        if containsSymbolicLinkInLocalPath(localURL, homeURL: homeURL, fileManager: fileManager) {
+            throw CustomDirValidationError.localIsSymlink
+        }
+
+        var isLocalDir: ObjCBool = false
+        guard fileManager.fileExists(atPath: localPath, isDirectory: &isLocalDir), isLocalDir.boolValue else {
+            throw CustomDirValidationError.localNotDirectory
+        }
+
+        if localPath == homePath {
+            throw CustomDirValidationError.localIsHome
+        }
+
+        guard isDescendant(localPath, of: homePath) else {
+            throw CustomDirValidationError.localOutsideHome
+        }
+
+        for config in existingConfigs {
+            if pathsOverlap(localPath, normalizedPath(config.localURL))
+                || pathsOverlap(localPath, normalizedPath(config.externalDestinationURL)) {
+                throw CustomDirValidationError.localOverlapsManagedDirectory
+            }
+        }
+    }
+
+    static func validate(
+        localURL: URL,
+        externalBaseURL: URL,
+        existingConfigs: [CustomDirConfig],
+        homeURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default
+    ) throws {
+        try validateLocalDirectory(
+            localURL,
+            existingConfigs: existingConfigs,
+            homeURL: homeURL,
+            fileManager: fileManager
+        )
+        try validateExternalBaseDirectory(
+            externalBaseURL,
+            homeURL: homeURL,
+            fileManager: fileManager
+        )
+
+        let localPath = normalizedPath(localURL)
+        let externalBasePath = normalizedPath(externalBaseURL)
+        let finalPath = normalizedPath(
+            externalBaseURL.appendingPathComponent(localURL.lastPathComponent)
+        )
+
+        if isDescendant(finalPath, of: localPath) {
+            throw CustomDirValidationError.externalInsideLocal
+        }
+
+        if isDescendant(localPath, of: finalPath) || localPath == externalBasePath {
+            throw CustomDirValidationError.localInsideExternal
+        }
+
+        for config in existingConfigs {
+            if pathsOverlap(finalPath, normalizedPath(config.localURL))
+                || pathsOverlap(finalPath, normalizedPath(config.externalDestinationURL)) {
+                throw CustomDirValidationError.externalOverlapsManagedDirectory
+            }
+        }
+    }
+
+    static func validateExternalBaseDirectory(
+        _ externalBaseURL: URL,
+        homeURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default
+    ) throws {
+        let externalBasePath = normalizedPath(externalBaseURL)
+        let homePath = normalizedPath(homeURL)
+
+        var isExternalDir: ObjCBool = false
+        guard fileManager.fileExists(atPath: externalBasePath, isDirectory: &isExternalDir),
+              isExternalDir.boolValue else {
+            throw CustomDirValidationError.externalNotDirectory
+        }
+
+        if isSameOrDescendant(externalBasePath, of: homePath) {
+            throw CustomDirValidationError.externalInsideHome
+        }
+    }
+
+    private static func isSymbolicLink(at url: URL, fileManager: FileManager) -> Bool {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),
+              let fileType = attributes[.type] as? FileAttributeType else {
+            return false
+        }
+        return fileType == .typeSymbolicLink
+    }
+
+    static func containsSymbolicLinkInLocalPath(
+        _ localURL: URL,
+        homeURL: URL,
+        fileManager: FileManager
+    ) -> Bool {
+        let localPath = normalizedPath(localURL)
+        let homePath = normalizedPath(homeURL)
+
+        guard isSameOrDescendant(localPath, of: homePath) else {
+            return isSymbolicLink(at: localURL, fileManager: fileManager)
+        }
+
+        var currentPath = localPath
+        while isSameOrDescendant(currentPath, of: homePath) {
+            if isSymbolicLink(at: URL(fileURLWithPath: currentPath), fileManager: fileManager) {
+                return true
+            }
+
+            if currentPath == homePath {
+                break
+            }
+
+            let parentPath = stripTrailingSlash(URL(fileURLWithPath: currentPath).deletingLastPathComponent().path)
+            guard parentPath != currentPath else {
+                break
+            }
+            currentPath = parentPath
+        }
+
+        return false
+    }
+
+    private static func pathsOverlap(_ lhs: String, _ rhs: String) -> Bool {
+        isSameOrDescendant(lhs, of: rhs) || isSameOrDescendant(rhs, of: lhs)
+    }
+
+    private static func isDescendant(_ candidate: String, of root: String) -> Bool {
+        candidate != root && isSameOrDescendant(candidate, of: root)
+    }
+
+    private static func isSameOrDescendant(_ candidate: String, of root: String) -> Bool {
+        let candidate = stripTrailingSlash(candidate)
+        let root = stripTrailingSlash(root)
+        return candidate == root || candidate.hasPrefix(root + "/")
+    }
+
+    private static func normalizedPath(_ url: URL) -> String {
+        stripTrailingSlash(url.standardizedFileURL.path)
+    }
+
+    private static func stripTrailingSlash(_ path: String) -> String {
+        guard path.count > 1 else { return path }
+        return path.hasSuffix("/") ? String(path.dropLast()) : path
+    }
+}
+
+struct CustomDirLocalOpenPanelGuard {
+    private let homeURL: URL
+    private let existingConfigs: [CustomDirConfig]
+    private let fileManager: FileManager
+
+    init(
+        homeURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+        existingConfigs: [CustomDirConfig],
+        fileManager: FileManager = .default
+    ) {
+        self.homeURL = homeURL
+        self.existingConfigs = existingConfigs
+        self.fileManager = fileManager
+    }
+
+    func shouldEnable(_ url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            return false
+        }
+
+        return !CustomDirValidator.containsSymbolicLinkInLocalPath(
+            url,
+            homeURL: homeURL,
+            fileManager: fileManager
+        )
+    }
+
+    func validationError(for url: URL) -> Error? {
+        do {
+            try CustomDirValidator.validateLocalDirectory(
+                url,
+                existingConfigs: existingConfigs,
+                homeURL: homeURL,
+                fileManager: fileManager
+            )
+            return nil
+        } catch {
+            return error
+        }
+    }
+}
+
+enum CustomDirEntryKind: String, Sendable {
+    case local
+    case external
+}
+
+struct CustomDirEntry: Identifiable, Equatable, Sendable {
+    var config: CustomDirConfig
+    var kind: CustomDirEntryKind
+    var url: URL
+    var status: String
+    var size: String? = nil
+    var sizeBytes: Int64 = 0
+    var linkedDestination: URL? = nil
+
+    nonisolated var id: String {
+        "\(config.id.uuidString)-\(kind.rawValue)"
+    }
+
+    nonisolated var name: String {
+        config.displayName
+    }
+
+    nonisolated var counterpartURL: URL {
+        switch kind {
+        case .local:
+            return config.externalDestinationURL
+        case .external:
+            return config.localURL
+        }
+    }
+
+    nonisolated var dataDirItem: DataDirItem {
+        DataDirItem(
+            name: name,
+            path: url,
+            type: .custom,
+            priority: .recommended,
+            description: "目录迁移".localized,
+            status: status,
+            size: size,
+            sizeBytes: sizeBytes,
+            isMigratable: status == CustomDirStatus.local,
+            linkedDestination: linkedDestination
+        )
+    }
+}
+
+struct CustomDirPair: Identifiable, Equatable, Sendable {
+    var config: CustomDirConfig
+    var local: CustomDirEntry
+    var external: CustomDirEntry
+
+    nonisolated var id: UUID {
+        config.id
+    }
+
+    nonisolated static func pendingMigration(for config: CustomDirConfig) -> CustomDirPair {
+        CustomDirPair(
+            config: config,
+            local: CustomDirEntry(
+                config: config,
+                kind: .local,
+                url: config.localURL,
+                status: CustomDirStatus.local
+            ),
+            external: CustomDirEntry(
+                config: config,
+                kind: .external,
+                url: config.externalDestinationURL,
+                status: CustomDirStatus.missing
+            )
+        )
+    }
+}

--- a/AppPorts/Utils/CustomDirScanner.swift
+++ b/AppPorts/Utils/CustomDirScanner.swift
@@ -1,0 +1,111 @@
+//
+//  CustomDirScanner.swift
+//  AppPorts
+//
+//  Created by Codex on 2026/6/26.
+//
+
+import Foundation
+
+actor CustomDirScanner {
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    func scan(configs: [CustomDirConfig], calculateSizes: Bool = false) -> [CustomDirPair] {
+        configs.map { scan(config: $0, calculateSizes: calculateSizes) }
+    }
+
+    private func scan(config: CustomDirConfig, calculateSizes: Bool) -> CustomDirPair {
+        let localURL = config.localURL
+        let externalURL = config.externalDestinationURL
+        let localState = inspectLocal(localURL: localURL, expectedExternalURL: externalURL)
+        let externalExists = fileManager.fileExists(atPath: externalURL.path)
+        let externalStatus: String
+
+        if externalExists {
+            externalStatus = localState.status == CustomDirStatus.linked
+                ? CustomDirStatus.linked
+                : CustomDirStatus.pendingRelink
+        } else {
+            externalStatus = CustomDirStatus.missing
+        }
+
+        var localEntry = CustomDirEntry(
+            config: config,
+            kind: .local,
+            url: localURL,
+            status: localState.status,
+            linkedDestination: localState.linkedDestination
+        )
+        var externalEntry = CustomDirEntry(
+            config: config,
+            kind: .external,
+            url: externalURL,
+            status: externalStatus,
+            linkedDestination: localState.status == CustomDirStatus.linked ? localURL : nil
+        )
+
+        if calculateSizes {
+            applySize(to: &localEntry)
+            applySize(to: &externalEntry)
+        }
+
+        return CustomDirPair(config: config, local: localEntry, external: externalEntry)
+    }
+
+    private func inspectLocal(localURL: URL, expectedExternalURL: URL) -> (status: String, linkedDestination: URL?) {
+        if isSymbolicLink(at: localURL) {
+            guard let destination = resolveSymlinkDestination(of: localURL) else {
+                return (CustomDirStatus.orphanedLink, nil)
+            }
+
+            if fileManager.fileExists(atPath: destination.path) {
+                let status = destination.standardizedFileURL == expectedExternalURL.standardizedFileURL
+                    ? CustomDirStatus.linked
+                    : CustomDirStatus.destinationConflict
+                return (status, destination.standardizedFileURL)
+            }
+
+            return (CustomDirStatus.orphanedLink, destination.standardizedFileURL)
+        }
+
+        if fileManager.fileExists(atPath: localURL.path) {
+            return (CustomDirStatus.local, nil)
+        }
+
+        return (CustomDirStatus.missing, nil)
+    }
+
+    private func applySize(to entry: inout CustomDirEntry) {
+        guard fileManager.fileExists(atPath: entry.url.path) else { return }
+        let sizeBytes = fastDirectorySize(at: entry.url, fileManager: fileManager)
+        entry.sizeBytes = sizeBytes
+        entry.size = LocalizedByteCountFormatter.string(fromByteCount: sizeBytes)
+    }
+
+    private func isSymbolicLink(at url: URL) -> Bool {
+        guard let attrs = try? fileManager.attributesOfItem(atPath: url.path),
+              let fileType = attrs[.type] as? FileAttributeType else {
+            return false
+        }
+        return fileType == .typeSymbolicLink
+    }
+
+    private func resolveSymlinkDestination(of url: URL) -> URL? {
+        guard let destinationPath = try? fileManager.destinationOfSymbolicLink(atPath: url.path) else {
+            return nil
+        }
+
+        if destinationPath.hasPrefix("/") {
+            return URL(fileURLWithPath: destinationPath).standardizedFileURL
+        }
+
+        return url
+            .deletingLastPathComponent()
+            .appendingPathComponent(destinationPath)
+            .standardizedFileURL
+    }
+}

--- a/AppPorts/Utils/DataDirMover.swift
+++ b/AppPorts/Utils/DataDirMover.swift
@@ -597,6 +597,78 @@ actor DataDirMover {
         operationResult = "success"
     }
 
+    // MARK: - 删除本地链接
+
+    /// 删除本地符号链接，保留外部真实目录。
+    ///
+    /// 适用场景：用户想断开本地入口，但继续保留外部存储中的目录，之后可再接回。
+    ///
+    /// - Parameter localPath: 本地原路径（必须是符号链接）
+    ///
+    /// - Throws: 文件系统错误、目标不是符号链接
+    func deleteLink(localPath: URL) throws {
+        let operationID = AppLogger.shared.makeOperationID(prefix: "data-unlink")
+        let startedAt = Date()
+        var operationResult = "failed"
+        var operationErrorCode: String?
+
+        defer {
+            AppLogger.shared.logOperationSummary(
+                category: "data_unlink",
+                operationID: operationID,
+                result: operationResult,
+                startedAt: startedAt,
+                errorCode: operationErrorCode,
+                details: [
+                    ("local_path", localPath.path)
+                ]
+            )
+        }
+
+        AppLogger.shared.logContext(
+            "开始删除数据目录本地链接",
+            details: [
+                ("operation_id", operationID),
+                ("local_path", localPath.path)
+            ]
+        )
+        AppLogger.shared.logPathState("删除数据目录链接前-本地路径[\(operationID)]", url: localPath)
+
+        do {
+            try checkWritePermission(at: localPath.deletingLastPathComponent())
+        } catch {
+            operationErrorCode = "DATA-UNLINK-PERMISSION-DENIED"
+            throw error
+        }
+
+        guard isSymbolicLink(at: localPath) else {
+            AppLogger.shared.logError(
+                "删除数据目录本地链接失败：本地路径不是符号链接",
+                errorCode: "DATA-UNLINK-NOT-A-SYMLINK",
+                context: [("operation_id", operationID)],
+                relatedURLs: [("local", localPath)]
+            )
+            operationErrorCode = "DATA-UNLINK-NOT-A-SYMLINK"
+            throw DataDirError.notASymlink(localPath)
+        }
+
+        do {
+            try fileManager.removeItem(at: localPath)
+            AppLogger.shared.logPathState("删除数据目录链接后-本地路径[\(operationID)]", url: localPath)
+            operationResult = "success"
+        } catch {
+            AppLogger.shared.logError(
+                "删除数据目录本地链接失败",
+                error: error,
+                errorCode: "DATA-UNLINK-REMOVE-FAILED",
+                context: [("operation_id", operationID)],
+                relatedURLs: [("local", localPath)]
+            )
+            operationErrorCode = "DATA-UNLINK-REMOVE-FAILED"
+            throw DataDirError.deletionFailed(error)
+        }
+    }
+
     /// 将现有软链接纳入 AppPorts 管理，并在需要时迁移到规范路径。
     ///
     /// 如果当前外部路径与规范路径不同，会先移动外部目录/文件，再重建本地软链接。

--- a/AppPorts/Utils/DataDirMover.swift
+++ b/AppPorts/Utils/DataDirMover.swift
@@ -16,7 +16,7 @@ import Foundation
 /// 原路径整体变为符号链接，指向外部存储中的目录。
 ///
 /// ## 操作流程
-/// - **迁移**：复制 → 删除原目录 → 创建符号链接
+/// - **迁移**：复制 → 将原目录改名为安全备份 → 创建符号链接 → 清理备份
 /// - **还原**：复制回来 → 删除外部目录 → 删除符号链接
 /// - **仅链接**：直接在原路径创建符号链接（适用于已手动迁移的情况）
 actor DataDirMover {
@@ -24,6 +24,7 @@ actor DataDirMover {
     private let fileManager = FileManager.default
     private let homeDir: URL
     private let failSymlinkCreation: Bool
+    private let failSourceBackupCleanup: Bool
     private let managedLinkMarkerFileName = ".appports-link-metadata.plist"
     private let managedLinkMetadataSidecarSuffix = ".appports-link-metadata.plist"
     private let managedLinkIdentifier = "com.shimoko.AppPorts"
@@ -39,10 +40,12 @@ actor DataDirMover {
 
     init(
         homeDir: URL = URL(fileURLWithPath: NSHomeDirectory()),
-        failSymlinkCreation: Bool = false
+        failSymlinkCreation: Bool = false,
+        failSourceBackupCleanup: Bool = false
     ) {
         self.homeDir = homeDir.standardizedFileURL
         self.failSymlinkCreation = failSymlinkCreation
+        self.failSourceBackupCleanup = failSourceBackupCleanup
     }
 
     // MARK: - 迁移
@@ -53,8 +56,9 @@ actor DataDirMover {
     /// 1. 权限检查（确认能写入目标路径的父目录）
     /// 2. 检测目标冲突
     /// 3. 使用 FileCopier 复制（带进度回调）
-    /// 4. 删除原目录
+    /// 4. 将原目录改名为本地安全备份
     /// 5. 在原路径创建指向外部的符号链接
+    /// 6. 清理本地安全备份
     ///
     /// - Parameters:
     ///   - item: 要迁移的数据目录项
@@ -144,49 +148,63 @@ actor DataDirMover {
                 if hasMatchingManagedLinkMetadata(at: destPath, sourcePath: sourcePath, destinationPath: destPath, type: item.type) {
                     AppLogger.shared.log("目标目录包含匹配的 AppPorts 链接标记，视为上次迁移完成但未清理源，自动恢复...", level: "WARN")
                     do {
-                        try fileManager.removeItem(at: sourcePath)
-                        AppLogger.shared.log("已删除源目录（标记恢复模式）")
+                        try writeManagedLinkMetadata(sourcePath: sourcePath, destinationPath: destPath, type: item.type)
                     } catch {
                         AppLogger.shared.logError(
-                            "标记恢复模式：删除源目录失败",
+                            "标记恢复模式：写入 AppPorts 链接标记失败",
                             error: error,
-                            errorCode: "DATA-MIGRATE-RECOVERY-DELETE-FAILED",
+                            errorCode: "DATA-MIGRATE-RECOVERY-METADATA-WRITE-FAILED",
                             context: [("operation_id", operationID)],
-                            relatedURLs: [("source", sourcePath)]
+                            relatedURLs: [("source", sourcePath), ("destination", destPath)]
                         )
-                        operationErrorCode = "DATA-MIGRATE-RECOVERY-DELETE-FAILED"
+                        operationErrorCode = "DATA-MIGRATE-RECOVERY-METADATA-WRITE-FAILED"
+                        throw DataDirError.metadataWriteFailed(error)
+                    }
+                    let sourceBackupPath: URL
+                    do {
+                        sourceBackupPath = try moveSourceToMigrationBackup(sourcePath, operationID: operationID)
+                    } catch {
+                        AppLogger.shared.logError(
+                            "标记恢复模式：移动源目录到安全备份失败，保留外部副本",
+                            error: error,
+                            errorCode: "DATA-MIGRATE-RECOVERY-BACKUP-MOVE-FAILED",
+                            context: [("operation_id", operationID)],
+                            relatedURLs: [("source", sourcePath), ("destination", destPath)]
+                        )
+                        operationErrorCode = "DATA-MIGRATE-RECOVERY-BACKUP-MOVE-FAILED"
                         throw DataDirError.deletionFailed(error)
                     }
                     do {
-                        try writeManagedLinkMetadata(sourcePath: sourcePath, destinationPath: destPath, type: item.type)
                         try createSymbolicLink(at: sourcePath, withDestinationURL: destPath)
                         AppLogger.shared.log("标记恢复模式：符号链接创建成功")
                         AppLogger.shared.logPathState("标记恢复完成-本地链接[\(operationID)]", url: sourcePath)
                         AppLogger.shared.logPathState("标记恢复完成-外部目标[\(operationID)]", url: destPath)
-                        operationResult = "success"
                     } catch {
                         AppLogger.shared.logError(
-                            "标记恢复模式：创建符号链接失败，尝试紧急回滚",
+                            "标记恢复模式：创建符号链接失败，恢复本地安全备份，保留外部副本",
                             error: error,
                             errorCode: "DATA-MIGRATE-RECOVERY-LINK-FAILED",
                             context: [("operation_id", operationID)],
-                            relatedURLs: [("source", sourcePath), ("destination", destPath)]
+                            relatedURLs: [("source", sourcePath), ("destination", destPath), ("backup", sourceBackupPath)]
                         )
-                        // 紧急回滚：将外部数据复制回源路径
-                        let emergencyCopier = FileCopier()
-                        try? await emergencyCopier.copyDirectory(from: destPath, to: sourcePath, progressHandler: nil)
+                        restoreMigrationBackup(sourceBackupPath, to: sourcePath, operationID: operationID)
                         try? removeManagedLinkMetadata(in: sourcePath)
-                        if fileManager.fileExists(atPath: sourcePath.path) {
-                            AppLogger.shared.log("标记恢复模式：紧急回滚成功，数据已恢复到本地", level: "WARN")
-                        } else {
-                            AppLogger.shared.logError(
-                                "标记恢复模式：紧急回滚也失败，数据仅在外部存储中",
-                                errorCode: "DATA-MIGRATE-RECOVERY-ROLLBACK-FAILED",
-                                context: [("operation_id", operationID), ("external_path", destPath.path)]
-                            )
-                        }
                         operationErrorCode = "DATA-MIGRATE-RECOVERY-LINK-FAILED"
                         throw DataDirError.symlinkFailed(error)
+                    }
+                    do {
+                        try cleanupMigrationBackup(sourceBackupPath, operationID: operationID)
+                        operationResult = "success"
+                    } catch {
+                        AppLogger.shared.logError(
+                            "标记恢复模式：迁移已完成，但本地安全备份清理失败，外部副本保持不变",
+                            error: error,
+                            errorCode: "DATA-MIGRATE-RECOVERY-BACKUP-CLEANUP-FAILED",
+                            context: [("operation_id", operationID)],
+                            relatedURLs: [("backup", sourceBackupPath), ("destination", destPath)]
+                        )
+                        operationResult = "success_with_warning"
+                        operationErrorCode = "DATA-MIGRATE-RECOVERY-BACKUP-CLEANUP-FAILED"
                     }
                     return
                 }
@@ -241,26 +259,24 @@ actor DataDirMover {
             throw DataDirError.metadataWriteFailed(error)
         }
 
-        // 4. 删除原目录（先尝试普通删除）
-        AppLogger.shared.log("步骤2: 删除原目录...")
-        await progressHandler?(FileCopier.Progress(copiedBytes: totalBytes, totalBytes: totalBytes, currentFile: "正在删除原目录...".localized))
+        // 4. 将原目录改名为同卷安全备份，避免递归删除失败造成源和目标双丢失
+        AppLogger.shared.log("步骤2: 将原目录移动到本地安全备份...")
+        await progressHandler?(FileCopier.Progress(copiedBytes: totalBytes, totalBytes: totalBytes, currentFile: "正在切换本地入口...".localized))
+        let sourceBackupPath: URL
         do {
-            try fileManager.removeItem(at: sourcePath)
-            AppLogger.shared.log("步骤2: 删除成功")
+            sourceBackupPath = try moveSourceToMigrationBackup(sourcePath, operationID: operationID)
+            AppLogger.shared.log("步骤2: 原目录已移动到本地安全备份")
             AppLogger.shared.logPathState("数据目录步骤2后-本地源[\(operationID)]", url: sourcePath)
+            AppLogger.shared.logPathState("数据目录步骤2后-本地安全备份[\(operationID)]", url: sourceBackupPath)
         } catch {
-            // 回滚：删除外部已复制的目录
             AppLogger.shared.logError(
-                "步骤2: 删除失败，执行回滚",
+                "步骤2: 移动原目录到本地安全备份失败，保留外部副本",
                 error: error,
-                errorCode: "DATA-MIGRATE-SOURCE-DELETE-FAILED",
+                errorCode: "DATA-MIGRATE-SOURCE-BACKUP-MOVE-FAILED",
                 context: [("operation_id", operationID)],
                 relatedURLs: [("source", sourcePath), ("destination", destPath)]
             )
-            cleanupFailedMigrationDestination(at: destPath, within: externalBaseURL, operationID: operationID)
-            AppLogger.shared.log("回滚：已删除外部副本")
-            operationResult = "rolled_back"
-            operationErrorCode = "DATA-MIGRATE-SOURCE-DELETE-FAILED"
+            operationErrorCode = "DATA-MIGRATE-SOURCE-BACKUP-MOVE-FAILED"
             throw DataDirError.deletionFailed(error)
         }
 
@@ -272,23 +288,31 @@ actor DataDirMover {
             AppLogger.shared.log("步骤3: 符号链接创建成功: \(sourcePath.path) → \(destPath.path)")
             AppLogger.shared.logPathState("数据目录步骤3后-本地入口[\(operationID)]", url: sourcePath)
         } catch {
-            // 符号链接创建失败是严重错误：数据已在外部，但原路径为空
-            // 尝试把数据复制回来作为应急回滚
             AppLogger.shared.logError(
-                "步骤3: 符号链接创建失败，紧急回滚",
+                "步骤3: 符号链接创建失败，恢复本地安全备份，保留外部副本",
                 error: error,
                 errorCode: "DATA-MIGRATE-SYMLINK-FAILED",
                 context: [("operation_id", operationID)],
-                relatedURLs: [("source", sourcePath), ("destination", destPath)]
+                relatedURLs: [("source", sourcePath), ("destination", destPath), ("backup", sourceBackupPath)]
             )
-            let emergencyCopier = FileCopier()
-            try? await emergencyCopier.copyDirectory(from: destPath, to: sourcePath, progressHandler: nil)
+            restoreMigrationBackup(sourceBackupPath, to: sourcePath, operationID: operationID)
             try? removeManagedLinkMetadata(in: sourcePath)
-            cleanupFailedMigrationDestination(at: destPath, within: externalBaseURL, operationID: operationID)
-            AppLogger.shared.log("紧急回滚完成：数据已恢复到本地")
-            operationResult = "rolled_back"
             operationErrorCode = "DATA-MIGRATE-SYMLINK-FAILED"
             throw DataDirError.symlinkFailed(error)
+        }
+
+        do {
+            try cleanupMigrationBackup(sourceBackupPath, operationID: operationID)
+        } catch {
+            AppLogger.shared.logError(
+                "迁移已完成，但本地安全备份清理失败，外部副本保持不变",
+                error: error,
+                errorCode: "DATA-MIGRATE-BACKUP-CLEANUP-FAILED",
+                context: [("operation_id", operationID)],
+                relatedURLs: [("backup", sourceBackupPath), ("destination", destPath)]
+            )
+            operationResult = "success_with_warning"
+            operationErrorCode = "DATA-MIGRATE-BACKUP-CLEANUP-FAILED"
         }
 
         AppLogger.shared.log("===== 数据目录迁移完成 =====")
@@ -296,7 +320,9 @@ actor DataDirMover {
         AppLogger.shared.logPathState("数据目录迁移完成-外部目标[\(operationID)]", url: destPath)
         invalidateSizeCache(for: sourcePath)
         invalidateSizeCache(for: destPath)
-        operationResult = "success"
+        if operationResult != "success_with_warning" {
+            operationResult = "success"
+        }
     }
 
     // MARK: - 还原
@@ -851,6 +877,85 @@ actor DataDirMover {
             startingAt: standardizedDestination.deletingLastPathComponent(),
             upToIncluding: standardizedCleanupRoot,
             operationID: operationID
+        )
+    }
+
+    private func moveSourceToMigrationBackup(_ sourcePath: URL, operationID: String) throws -> URL {
+        let backupURL = makeMigrationBackupURL(for: sourcePath)
+        try fileManager.moveItem(at: sourcePath, to: backupURL)
+        AppLogger.shared.logContext(
+            "迁移安全备份：已将源目录改名",
+            details: [
+                ("operation_id", operationID),
+                ("source_path", sourcePath.path),
+                ("backup_path", backupURL.path)
+            ],
+            level: "TRACE"
+        )
+        return backupURL
+    }
+
+    private func makeMigrationBackupURL(for sourcePath: URL) -> URL {
+        let parentURL = sourcePath.deletingLastPathComponent()
+        let backupName = ".appports-migration-backup-\(sourcePath.lastPathComponent)-\(UUID().uuidString)"
+        return parentURL.appendingPathComponent(backupName)
+    }
+
+    private func restoreMigrationBackup(_ backupURL: URL, to sourcePath: URL, operationID: String) {
+        if fileManager.fileExists(atPath: sourcePath.path) {
+            if isSymbolicLink(at: sourcePath) {
+                try? fileManager.removeItem(at: sourcePath)
+            } else {
+                AppLogger.shared.logError(
+                    "迁移安全备份：源路径已存在，未覆盖恢复",
+                    errorCode: "DATA-MIGRATE-BACKUP-RESTORE-SOURCE-EXISTS",
+                    context: [("operation_id", operationID)],
+                    relatedURLs: [("source", sourcePath), ("backup", backupURL)]
+                )
+                return
+            }
+        }
+
+        do {
+            try fileManager.moveItem(at: backupURL, to: sourcePath)
+            AppLogger.shared.logContext(
+                "迁移安全备份：已恢复到本地源路径",
+                details: [
+                    ("operation_id", operationID),
+                    ("source_path", sourcePath.path),
+                    ("backup_path", backupURL.path)
+                ],
+                level: "WARN"
+            )
+        } catch {
+            AppLogger.shared.logError(
+                "迁移安全备份：恢复到本地源路径失败，外部副本仍保留",
+                error: error,
+                errorCode: "DATA-MIGRATE-BACKUP-RESTORE-FAILED",
+                context: [("operation_id", operationID)],
+                relatedURLs: [("source", sourcePath), ("backup", backupURL)]
+            )
+        }
+    }
+
+    private func cleanupMigrationBackup(_ backupURL: URL, operationID: String) throws {
+        if failSourceBackupCleanup {
+            throw NSError(
+                domain: "AppPorts.DataDirMover",
+                code: 9002,
+                userInfo: [NSLocalizedDescriptionKey: "forced source backup cleanup failure"]
+            )
+        }
+
+        guard fileManager.fileExists(atPath: backupURL.path) else { return }
+        try fileManager.removeItem(at: backupURL)
+        AppLogger.shared.logContext(
+            "迁移安全备份：已清理本地备份",
+            details: [
+                ("operation_id", operationID),
+                ("backup_path", backupURL.path)
+            ],
+            level: "TRACE"
         )
     }
 

--- a/AppPorts/Views/Components/CustomDirRowView.swift
+++ b/AppPorts/Views/Components/CustomDirRowView.swift
@@ -1,0 +1,136 @@
+//
+//  CustomDirRowView.swift
+//  AppPorts
+//
+//  Created by Codex on 2026/6/26.
+//
+
+import SwiftUI
+import AppKit
+
+struct CustomDirRowView: View {
+    let entry: CustomDirEntry
+    let isSelected: Bool
+    let onDeleteLink: (CustomDirEntry) -> Void
+    let onRemove: (CustomDirConfig) -> Void
+
+    @State private var isHovered = false
+
+    private var showsDeleteLinkButton: Bool {
+        entry.kind == .local
+            && (entry.status == CustomDirStatus.linked || entry.status == CustomDirStatus.orphanedLink)
+    }
+
+    var body: some View {
+        HStack(spacing: 14) {
+            Image(systemName: entry.kind == .local ? "folder.fill" : "externaldrive.fill")
+                .font(.system(size: 24))
+                .symbolRenderingMode(.hierarchical)
+                .foregroundColor(entry.kind == .local ? .accentColor : .teal)
+                .frame(width: 32)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(entry.name)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(.primary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                Text(entry.url.path)
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                HStack(spacing: 8) {
+                    CustomDirStatusBadge(status: entry.status)
+
+                    if let size = entry.size {
+                        Text(size)
+                            .font(.system(size: 11))
+                            .foregroundColor(.secondary)
+                    } else if entry.status != CustomDirStatus.missing {
+                        Text("计算中...".localized)
+                            .font(.system(size: 10))
+                            .foregroundColor(.secondary.opacity(0.5))
+                    }
+                }
+            }
+
+            Spacer()
+
+            if showsDeleteLinkButton {
+                Button(action: { onDeleteLink(entry) }) {
+                    Image(systemName: "link.badge.plus")
+                        .foregroundColor(.red)
+                }
+                .buttonStyle(.plain)
+                .padding(6)
+                .background(Color.red.opacity(0.1))
+                .clipShape(Circle())
+                .help("断开此链接并保留外部文件夹".localized)
+            }
+        }
+        .padding(.vertical, 10)
+        .padding(.horizontal, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(isSelected ? Color.accentColor.opacity(0.1) : (isHovered ? Color.primary.opacity(0.04) : Color.clear))
+        )
+        .contentShape(Rectangle())
+        .onHover { hovering in
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isHovered = hovering
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(entry.name) + Text(", ") + Text(entry.status.localized))
+        .contextMenu {
+            Button("在 Finder 中显示".localized) {
+                NSWorkspace.shared.activateFileViewerSelecting([entry.url])
+            }
+
+            if showsDeleteLinkButton {
+                Divider()
+                Button("断开链接".localized) {
+                    onDeleteLink(entry)
+                }
+            }
+
+            Divider()
+
+            Button("移除记录".localized) {
+                onRemove(entry.config)
+            }
+        }
+    }
+}
+
+private struct CustomDirStatusBadge: View {
+    let status: String
+
+    private var color: Color {
+        switch status {
+        case CustomDirStatus.local:
+            return .blue
+        case CustomDirStatus.linked:
+            return .green
+        case CustomDirStatus.pendingRelink:
+            return .orange
+        case CustomDirStatus.orphanedLink, CustomDirStatus.destinationConflict:
+            return .red
+        default:
+            return .secondary
+        }
+    }
+
+    var body: some View {
+        Text(status.localized)
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundColor(color)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.12))
+            .cornerRadius(5)
+    }
+}

--- a/AppPorts/Views/CustomDirsView.swift
+++ b/AppPorts/Views/CustomDirsView.swift
@@ -1,0 +1,670 @@
+//
+//  CustomDirsView.swift
+//  AppPorts
+//
+//  Created by Codex on 2026/6/26.
+//
+
+import SwiftUI
+import AppKit
+
+struct CustomDirsView: View {
+    @State private var configs: [CustomDirConfig] = CustomDirConfigStore.load()
+    @State private var pairs: [CustomDirPair] = []
+    @State private var selectedLocalIDs: Set<String> = []
+    @State private var selectedExternalIDs: Set<String> = []
+    @State private var isScanning = false
+    @State private var showAddSheet = false
+    @State private var showError = false
+    @State private var errorMessage = ""
+
+    @State private var showProgress = false
+    @State private var progressTitle = ""
+    @State private var progressBytes: Int64 = 0
+    @State private var progressTotalBytes: Int64 = 0
+    @State private var progressFileName = ""
+
+    private var localEntries: [CustomDirEntry] {
+        pairs.map(\.local)
+    }
+
+    private var externalEntries: [CustomDirEntry] {
+        pairs.map(\.external)
+    }
+
+    private var selectedLocalPairs: [CustomDirPair] {
+        pairs.filter { selectedLocalIDs.contains($0.local.id) }
+    }
+
+    private var selectedExternalPairs: [CustomDirPair] {
+        pairs.filter { selectedExternalIDs.contains($0.external.id) }
+    }
+
+    private var migratablePairs: [CustomDirPair] {
+        selectedLocalPairs.filter { $0.local.status == CustomDirStatus.local }
+    }
+
+    private var relinkablePairs: [CustomDirPair] {
+        selectedExternalPairs.filter { $0.external.status == CustomDirStatus.pendingRelink }
+    }
+
+    private var restorablePairs: [CustomDirPair] {
+        selectedExternalPairs.filter { $0.external.status == CustomDirStatus.linked }
+    }
+
+    var body: some View {
+        ZStack {
+            HSplitView {
+                localPane
+                    .frame(minWidth: 320, maxWidth: .infinity)
+
+                externalPane
+                    .frame(minWidth: 320, maxWidth: .infinity)
+            }
+
+            if showProgress {
+                Color.black.opacity(0.2)
+                    .ignoresSafeArea()
+
+                DataDirProgressOverlay(
+                    title: progressTitle,
+                    copiedBytes: progressBytes,
+                    totalBytes: progressTotalBytes,
+                    currentFile: progressFileName
+                )
+            }
+        }
+        .onAppear {
+            refresh()
+        }
+        .sheet(isPresented: $showAddSheet) {
+            AddCustomDirSheet(existingConfigs: configs) { config in
+                addAndMigrateConfig(config)
+            }
+        }
+        .alert("操作失败".localized, isPresented: $showError) {
+            Button("好的".localized, role: .cancel) {}
+        } message: {
+            Text(errorMessage)
+        }
+    }
+
+    private var localPane: some View {
+        VStack(spacing: 0) {
+            ContentView.HeaderView(
+                title: "本地文件夹",
+                subtitle: String(format: "%lld 个目录".localized, Int64(configs.count)),
+                icon: "folder.fill",
+                actionButtonText: "＋",
+                onAction: { showAddSheet = true }
+            )
+
+            ZStack {
+                Color(nsColor: .controlBackgroundColor).ignoresSafeArea()
+
+                if isScanning && localEntries.isEmpty {
+                    ContentView.EmptyStateView(icon: "magnifyingglass", text: "正在扫描...".localized)
+                } else if localEntries.isEmpty {
+                    ContentView.EmptyStateView(icon: "folder.badge.plus", text: "未添加目录迁移".localized)
+                } else {
+                    List(localEntries, selection: $selectedLocalIDs) { entry in
+                        CustomDirRowView(
+                            entry: entry,
+                            isSelected: selectedLocalIDs.contains(entry.id),
+                            onDeleteLink: deleteLocalLink,
+                            onRemove: removeConfig
+                        )
+                        .tag(entry.id)
+                        .listRowInsets(EdgeInsets(top: 4, leading: 10, bottom: 4, trailing: 10))
+                    }
+                    .listStyle(.plain)
+                }
+            }
+
+            ContentView.ActionFooter(
+                title: migrateButtonTitle,
+                icon: "arrow.right",
+                isEnabled: !migratablePairs.isEmpty,
+                action: migrateSelected
+            )
+        }
+    }
+
+    private var externalPane: some View {
+        VStack(spacing: 0) {
+            ContentView.HeaderView(
+                title: "外部文件夹",
+                subtitle: String(format: "%lld 个目录".localized, Int64(configs.count)),
+                icon: "externaldrive.fill"
+            )
+
+            ZStack {
+                Color(nsColor: .windowBackgroundColor).ignoresSafeArea()
+
+                if externalEntries.isEmpty {
+                    ContentView.EmptyStateView(icon: "externaldrive.badge.plus", text: "未添加目录迁移".localized)
+                } else {
+                    List(externalEntries, selection: $selectedExternalIDs) { entry in
+                        CustomDirRowView(
+                            entry: entry,
+                            isSelected: selectedExternalIDs.contains(entry.id),
+                            onDeleteLink: deleteLocalLink,
+                            onRemove: removeConfig
+                        )
+                        .tag(entry.id)
+                        .listRowInsets(EdgeInsets(top: 4, leading: 10, bottom: 4, trailing: 10))
+                    }
+                    .listStyle(.plain)
+                }
+            }
+
+            VStack(spacing: 0) {
+                Divider()
+                    .shadow(color: .black.opacity(0.05), radius: 1, x: 0, y: -1)
+
+                HStack(spacing: 8) {
+                    Button(action: relinkSelected) {
+                        footerLabel(title: relinkButtonTitle, icon: "link")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.blue)
+                    .disabled(relinkablePairs.isEmpty)
+
+                    Button(action: restoreSelected) {
+                        footerLabel(title: restoreButtonTitle, icon: "arrow.turn.up.left")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.orange.opacity(0.85))
+                    .disabled(restorablePairs.isEmpty)
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+            }
+            .background(.bar)
+        }
+    }
+
+    private var migrateButtonTitle: String {
+        if migratablePairs.isEmpty {
+            return "迁移文件夹".localized
+        }
+        return String(format: "迁移 %lld 个文件夹".localized, Int64(migratablePairs.count))
+    }
+
+    private var relinkButtonTitle: String {
+        if relinkablePairs.isEmpty {
+            return "接回文件夹".localized
+        }
+        return String(format: "接回 %lld 个文件夹".localized, Int64(relinkablePairs.count))
+    }
+
+    private var restoreButtonTitle: String {
+        if restorablePairs.isEmpty {
+            return "还原文件夹".localized
+        }
+        return String(format: "还原 %lld 个文件夹".localized, Int64(restorablePairs.count))
+    }
+
+    private func footerLabel(title: String, icon: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 12, weight: .medium))
+            Text(title.localized)
+                .fontWeight(.medium)
+                .font(.system(size: 13))
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 28)
+    }
+
+    private func addConfig(_ config: CustomDirConfig) -> String? {
+        guard !configs.contains(where: { $0.localURL == config.localURL }) else {
+            return "该目录已在目录迁移列表中".localized
+        }
+
+        do {
+            try CustomDirValidator.validate(
+                localURL: config.localURL,
+                externalBaseURL: config.externalBaseURL,
+                existingConfigs: configs
+            )
+        } catch {
+            return error.localizedDescription
+        }
+
+        configs.append(config)
+        saveConfigs()
+        return nil
+    }
+
+    private func addAndMigrateConfig(_ config: CustomDirConfig) -> String? {
+        if let errorMessage = addConfig(config) {
+            return errorMessage
+        }
+
+        runBatch(
+            title: "正在迁移目录".localized,
+            pairs: [CustomDirPair.pendingMigration(for: config)],
+            operation: migratePair
+        )
+        return nil
+    }
+
+    private func removeConfig(_ config: CustomDirConfig) {
+        configs.removeAll { $0.id == config.id }
+        selectedLocalIDs.remove("\(config.id.uuidString)-\(CustomDirEntryKind.local.rawValue)")
+        selectedExternalIDs.remove("\(config.id.uuidString)-\(CustomDirEntryKind.external.rawValue)")
+        saveConfigs()
+        refresh()
+    }
+
+    private func saveConfigs() {
+        CustomDirConfigStore.save(configs)
+    }
+
+    private func refresh() {
+        isScanning = true
+        Task {
+            let scanner = CustomDirScanner()
+            let result = await scanner.scan(configs: configs, calculateSizes: true)
+            await MainActor.run {
+                pairs = result
+                selectedLocalIDs.formIntersection(Set(result.map(\.local.id)))
+                selectedExternalIDs.formIntersection(Set(result.map(\.external.id)))
+                isScanning = false
+            }
+        }
+    }
+
+    private func migrateSelected() {
+        runBatch(
+            title: "正在迁移目录".localized,
+            pairs: migratablePairs,
+            operation: migratePair
+        )
+    }
+
+    private func migratePair(_ pair: CustomDirPair, progressHandler: FileCopier.ProgressHandler?) async throws {
+        let item = pair.local.dataDirItem
+        try await DataDirMover().migrate(
+            item: item,
+            to: pair.config.externalBaseURL,
+            progressHandler: progressHandler
+        )
+    }
+
+    private func relinkSelected() {
+        runBatch(
+            title: "正在接回目录".localized,
+            pairs: relinkablePairs,
+            operation: { pair, _ in
+                try await DataDirMover().createLink(
+                    localPath: pair.config.localURL,
+                    externalPath: pair.config.externalDestinationURL
+                )
+            }
+        )
+    }
+
+    private func restoreSelected() {
+        runBatch(
+            title: "正在还原目录".localized,
+            pairs: restorablePairs,
+            operation: { pair, progressHandler in
+                let item = pair.local.dataDirItem
+                try await DataDirMover().restore(item: item, progressHandler: progressHandler)
+            }
+        )
+    }
+
+    private func deleteLocalLink(_ entry: CustomDirEntry) {
+        guard entry.kind == .local else { return }
+
+        AppLogger.shared.logContext(
+            "用户请求断开目录迁移链接",
+            details: [
+                ("name", entry.name),
+                ("local_path", entry.url.path),
+                ("external_path", entry.counterpartURL.path),
+                ("status", entry.status)
+            ]
+        )
+
+        Task {
+            do {
+                try await DataDirMover().deleteLink(localPath: entry.url)
+                await MainActor.run {
+                    selectedLocalIDs.remove(entry.id)
+                    refresh()
+                }
+            } catch {
+                await MainActor.run {
+                    errorMessage = error.localizedDescription
+                    showError = true
+                    refresh()
+                }
+            }
+        }
+    }
+
+    private func runBatch(
+        title: String,
+        pairs selectedPairs: [CustomDirPair],
+        operation: @escaping (CustomDirPair, FileCopier.ProgressHandler?) async throws -> Void
+    ) {
+        guard !selectedPairs.isEmpty else { return }
+
+        progressTitle = title
+        progressBytes = 0
+        progressTotalBytes = 0
+        progressFileName = ""
+        showProgress = true
+
+        Task {
+            do {
+                for pair in selectedPairs {
+                    await MainActor.run {
+                        progressFileName = pair.config.displayName
+                    }
+
+                    try await operation(pair) { progress in
+                        await MainActor.run {
+                            progressBytes = progress.copiedBytes
+                            progressTotalBytes = progress.totalBytes
+                            progressFileName = progress.currentFile.isEmpty ? pair.config.displayName : progress.currentFile
+                        }
+                    }
+                }
+
+                await MainActor.run {
+                    showProgress = false
+                    selectedLocalIDs.removeAll()
+                    selectedExternalIDs.removeAll()
+                    refresh()
+                }
+            } catch {
+                await MainActor.run {
+                    showProgress = false
+                    errorMessage = error.localizedDescription
+                    showError = true
+                    refresh()
+                }
+            }
+        }
+    }
+}
+
+private final class CustomDirLocalOpenPanelDelegate: NSObject, NSOpenSavePanelDelegate {
+    private let guardrail: CustomDirLocalOpenPanelGuard
+
+    init(guardrail: CustomDirLocalOpenPanelGuard) {
+        self.guardrail = guardrail
+    }
+
+    func panel(_ sender: Any, shouldEnable url: URL) -> Bool {
+        guardrail.shouldEnable(url)
+    }
+
+    func panel(_ sender: Any, validate url: URL) throws {
+        if let error = guardrail.validationError(for: url) {
+            throw error
+        }
+    }
+}
+
+private enum CustomDirConfigStore {
+    private static let key = "customDirConfigs"
+
+    static func load() -> [CustomDirConfig] {
+        guard let data = UserDefaults.standard.data(forKey: key),
+              let configs = try? JSONDecoder().decode([CustomDirConfig].self, from: data) else {
+            return []
+        }
+        return configs
+    }
+
+    static func save(_ configs: [CustomDirConfig]) {
+        guard let data = try? JSONEncoder().encode(configs) else { return }
+        UserDefaults.standard.set(data, forKey: key)
+    }
+}
+
+private struct AddCustomDirSheet: View {
+    let existingConfigs: [CustomDirConfig]
+    let onMigrate: (CustomDirConfig) -> String?
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var localURL: URL?
+    @State private var externalBaseURL: URL?
+    @State private var errorMessage: String?
+
+    private var finalDestinationURL: URL? {
+        guard let localURL, let externalBaseURL else { return nil }
+        return externalBaseURL.appendingPathComponent(localURL.lastPathComponent).standardizedFileURL
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("添加目录迁移".localized)
+                .font(.title3.weight(.semibold))
+
+            directoryPickerRow(
+                title: "本地目录 - 只支持迁移用户目录下的文件夹".localized,
+                value: localURL?.path ?? "未选择".localized,
+                buttonTitle: "选择本地目录".localized,
+                buttonIcon: "folder.badge.plus",
+                action: chooseLocalDirectory
+            )
+
+            directoryPickerRow(
+                title: "外部目标文件夹".localized,
+                value: externalBaseURL?.path ?? "未选择".localized,
+                buttonTitle: "选择外部目标文件夹".localized,
+                buttonIcon: "externaldrive.badge.plus",
+                action: chooseExternalBaseDirectory
+            )
+
+            if let finalDestinationURL {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("最终位置".localized)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(.secondary)
+                    Text(finalDestinationURL.path)
+                        .font(.system(size: 12))
+                        .lineLimit(2)
+                        .truncationMode(.middle)
+                        .help(finalDestinationURL.path)
+                }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.primary.opacity(0.05))
+                .cornerRadius(8)
+            }
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.system(size: 12))
+                    .foregroundColor(.red)
+            }
+
+            HStack {
+                Spacer()
+                Button(action: {
+                    dismiss()
+                }) {
+                    sheetFooterLabel(title: "取消".localized, icon: "xmark")
+                }
+                .buttonStyle(.bordered)
+
+                Button(action: {
+                    add()
+                }) {
+                    sheetFooterLabel(title: "迁移".localized, icon: "arrow.right")
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.blue)
+                .disabled(localURL == nil || externalBaseURL == nil)
+            }
+        }
+        .padding(24)
+        .frame(width: 640)
+    }
+
+    private func directoryPickerRow(
+        title: String,
+        value: String,
+        buttonTitle: String,
+        buttonIcon: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        let placeholder = "未选择".localized
+
+        return VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(.secondary)
+
+            HStack(spacing: 10) {
+                Text(value)
+                    .font(.system(size: 13))
+                    .foregroundColor(value == placeholder ? .secondary : .primary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .padding(.horizontal, 14)
+                    .frame(height: 38)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(nsColor: .textBackgroundColor).opacity(0.72))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .stroke(Color.primary.opacity(0.09), lineWidth: 1)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    .help(value)
+
+                Button(action: action) {
+                    HStack(spacing: 6) {
+                        Image(systemName: buttonIcon)
+                            .font(.system(size: 13, weight: .semibold))
+                        Text(buttonTitle)
+                            .font(.system(size: 13, weight: .semibold))
+                            .lineLimit(1)
+                    }
+                    .foregroundColor(.accentColor)
+                    .padding(.horizontal, 14)
+                    .frame(height: 38)
+                    .frame(minWidth: 154)
+                    .background(Color.accentColor.opacity(0.09))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .stroke(Color.accentColor.opacity(0.18), lineWidth: 1)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                }
+                .buttonStyle(.plain)
+                .help(buttonTitle)
+            }
+        }
+    }
+
+    private func sheetFooterLabel(title: String, icon: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 12, weight: .medium))
+            Text(title)
+                .fontWeight(.medium)
+                .font(.system(size: 13))
+        }
+        .frame(minWidth: 82)
+        .frame(height: 28)
+    }
+
+    private func chooseLocalDirectory() {
+        let panelGuard = CustomDirLocalOpenPanelGuard(existingConfigs: existingConfigs)
+        if let url = chooseDirectory(
+            message: "选择要迁移的本地文件夹".localized,
+            startingAt: FileManager.default.homeDirectoryForCurrentUser,
+            localPanelGuard: panelGuard
+        ) {
+            do {
+                try CustomDirValidator.validateLocalDirectory(
+                    url,
+                    existingConfigs: existingConfigs
+                )
+            } catch {
+                localURL = nil
+                errorMessage = error.localizedDescription
+                return
+            }
+
+            localURL = url
+            errorMessage = nil
+        }
+    }
+
+    private func chooseExternalBaseDirectory() {
+        if let url = chooseDirectory(message: "选择外部目标父文件夹".localized) {
+            do {
+                try CustomDirValidator.validateExternalBaseDirectory(url)
+                if let localURL {
+                    try CustomDirValidator.validate(
+                        localURL: localURL,
+                        externalBaseURL: url,
+                        existingConfigs: existingConfigs
+                    )
+                }
+            } catch {
+                externalBaseURL = nil
+                errorMessage = error.localizedDescription
+                return
+            }
+
+            externalBaseURL = url
+            errorMessage = nil
+        }
+    }
+
+    private func chooseDirectory(
+        message: String,
+        startingAt directoryURL: URL? = nil,
+        localPanelGuard: CustomDirLocalOpenPanelGuard? = nil
+    ) -> URL? {
+        let panel = NSOpenPanel()
+        panel.prompt = "选择文件夹".localized
+        panel.message = message
+        panel.directoryURL = directoryURL
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.resolvesAliases = false
+
+        let panelDelegate = localPanelGuard.map(CustomDirLocalOpenPanelDelegate.init)
+        panel.delegate = panelDelegate
+        let response = withExtendedLifetime(panelDelegate) {
+            panel.runModal()
+        }
+        return response == .OK ? panel.url : nil
+    }
+
+    private func add() {
+        guard let localURL, let externalBaseURL else {
+            errorMessage = "请选择本地目录和外部目标文件夹".localized
+            return
+        }
+
+        do {
+            try CustomDirValidator.validate(
+                localURL: localURL,
+                externalBaseURL: externalBaseURL,
+                existingConfigs: existingConfigs
+            )
+            let config = CustomDirConfig(localPath: localURL.path, externalBasePath: externalBaseURL.path)
+            if let callbackError = onMigrate(config) {
+                errorMessage = callbackError
+                return
+            }
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/AppPortsTests/CustomDirScannerTests.swift
+++ b/AppPortsTests/CustomDirScannerTests.swift
@@ -1,0 +1,293 @@
+import XCTest
+@testable import AppPorts
+
+final class CustomDirScannerTests: XCTestCase {
+    private let fileManager = FileManager.default
+
+    func testConfigUsesExternalParentAndLocalFolderNameForDestination() {
+        let localURL = URL(fileURLWithPath: "/Users/ping/develop")
+        let externalBaseURL = URL(fileURLWithPath: "/Volumes/ExternalSSD/work")
+        let config = CustomDirConfig(localPath: localURL.path, externalBasePath: externalBaseURL.path)
+
+        XCTAssertEqual(
+            config.externalDestinationURL,
+            externalBaseURL.appendingPathComponent("develop").standardizedFileURL
+        )
+    }
+
+    func testMigrationPairForNewConfigUsesLocalSourceAndExternalDestination() {
+        let localURL = URL(fileURLWithPath: "/Users/ping/develop")
+        let externalBaseURL = URL(fileURLWithPath: "/Volumes/ExternalSSD/work")
+        let config = CustomDirConfig(localPath: localURL.path, externalBasePath: externalBaseURL.path)
+        let pair = CustomDirPair.pendingMigration(for: config)
+
+        XCTAssertEqual(pair.config, config)
+        XCTAssertEqual(pair.local.kind, .local)
+        XCTAssertEqual(pair.local.url, localURL.standardizedFileURL)
+        XCTAssertEqual(pair.local.status, CustomDirStatus.local)
+        XCTAssertTrue(pair.local.dataDirItem.isMigratable)
+        XCTAssertEqual(pair.external.kind, .external)
+        XCTAssertEqual(pair.external.url, externalBaseURL.appendingPathComponent("develop").standardizedFileURL)
+        XCTAssertEqual(pair.external.status, CustomDirStatus.missing)
+    }
+
+    func testScannerReportsLocalDirectoryAndMissingExternalDestination() async throws {
+        let workspace = try makeWorkspace()
+        defer { cleanupWorkspace(workspace.rootURL) }
+
+        let localURL = workspace.homeURL.appendingPathComponent("develop")
+        try createDirectoryWithPayload(at: localURL)
+
+        let config = CustomDirConfig(localPath: localURL.path, externalBasePath: workspace.externalBaseURL.path)
+        let scanner = CustomDirScanner(fileManager: fileManager)
+        let result = await scanner.scan(configs: [config])
+
+        let pair = try XCTUnwrap(result.first)
+        XCTAssertEqual(pair.local.status, CustomDirStatus.local)
+        XCTAssertEqual(pair.external.status, CustomDirStatus.missing)
+        XCTAssertEqual(pair.external.url, workspace.externalBaseURL.appendingPathComponent("develop").standardizedFileURL)
+    }
+
+    func testScannerReportsLinkedDirectoryAndExternalLinkedDestination() async throws {
+        let workspace = try makeWorkspace()
+        defer { cleanupWorkspace(workspace.rootURL) }
+
+        let localURL = workspace.homeURL.appendingPathComponent("develop")
+        let externalURL = workspace.externalBaseURL.appendingPathComponent("develop")
+        try createDirectoryWithPayload(at: externalURL)
+        try fileManager.createSymbolicLink(at: localURL, withDestinationURL: externalURL)
+
+        let config = CustomDirConfig(localPath: localURL.path, externalBasePath: workspace.externalBaseURL.path)
+        let scanner = CustomDirScanner(fileManager: fileManager)
+        let result = await scanner.scan(configs: [config])
+
+        let pair = try XCTUnwrap(result.first)
+        XCTAssertEqual(pair.local.status, CustomDirStatus.linked)
+        XCTAssertEqual(pair.local.linkedDestination, externalURL.standardizedFileURL)
+        XCTAssertEqual(pair.external.status, CustomDirStatus.linked)
+    }
+
+    func testScannerReportsExternalPendingRelinkWhenLocalPathIsMissing() async throws {
+        let workspace = try makeWorkspace()
+        defer { cleanupWorkspace(workspace.rootURL) }
+
+        let localURL = workspace.homeURL.appendingPathComponent("develop")
+        let externalURL = workspace.externalBaseURL.appendingPathComponent("develop")
+        try createDirectoryWithPayload(at: externalURL)
+
+        let config = CustomDirConfig(localPath: localURL.path, externalBasePath: workspace.externalBaseURL.path)
+        let scanner = CustomDirScanner(fileManager: fileManager)
+        let result = await scanner.scan(configs: [config])
+
+        let pair = try XCTUnwrap(result.first)
+        XCTAssertEqual(pair.local.status, CustomDirStatus.missing)
+        XCTAssertEqual(pair.external.status, CustomDirStatus.pendingRelink)
+    }
+
+    func testValidatorRejectsLocalDirectoryOutsideCurrentUserHome() throws {
+        let workspace = try makeWorkspace()
+        defer { cleanupWorkspace(workspace.rootURL) }
+
+        let outsideHomeURL = workspace.rootURL.appendingPathComponent("Outside/develop")
+        try fileManager.createDirectory(at: outsideHomeURL, withIntermediateDirectories: true)
+
+        XCTAssertThrowsError(
+            try CustomDirValidator.validateLocalDirectory(
+                outsideHomeURL,
+                existingConfigs: [],
+                homeURL: workspace.homeURL,
+                fileManager: fileManager
+            )
+        ) { error in
+            XCTAssertEqual(error as? CustomDirValidationError, .localOutsideHome)
+        }
+    }
+
+    func testValidatorRejectsCurrentUserHomeItself() throws {
+        let workspace = try makeWorkspace()
+        defer { cleanupWorkspace(workspace.rootURL) }
+
+        XCTAssertThrowsError(
+            try CustomDirValidator.validateLocalDirectory(
+                workspace.homeURL,
+                existingConfigs: [],
+                homeURL: workspace.homeURL,
+                fileManager: fileManager
+            )
+        ) { error in
+            XCTAssertEqual(error as? CustomDirValidationError, .localIsHome)
+        }
+    }
+
+    func testValidatorRejectsLocalSymlink() throws {
+        let workspace = try makeWorkspace()
+        defer { cleanupWorkspace(workspace.rootURL) }
+
+        let realURL = workspace.homeURL.appendingPathComponent("real")
+        let linkURL = workspace.homeURL.appendingPathComponent("linked")
+        try createDirectoryWithPayload(at: realURL)
+        try fileManager.createSymbolicLink(at: linkURL, withDestinationURL: realURL)
+
+        XCTAssertThrowsError(
+            try CustomDirValidator.validateLocalDirectory(
+                linkURL,
+                existingConfigs: [],
+                homeURL: workspace.homeURL,
+                fileManager: fileManager
+            )
+        ) { error in
+            XCTAssertEqual(error as? CustomDirValidationError, .localIsSymlink)
+        }
+    }
+
+    func testValidatorRejectsLocalDirectoryInsideSymlinkedParent() throws {
+        let workspace = try makeWorkspace()
+        defer { cleanupWorkspace(workspace.rootURL) }
+
+        let realParentURL = workspace.rootURL.appendingPathComponent("RealParent")
+        let realChildURL = realParentURL.appendingPathComponent("project")
+        let linkedParentURL = workspace.homeURL.appendingPathComponent("linked")
+        let linkedChildURL = linkedParentURL.appendingPathComponent("project")
+        try createDirectoryWithPayload(at: realChildURL)
+        try fileManager.createSymbolicLink(at: linkedParentURL, withDestinationURL: realParentURL)
+
+        XCTAssertThrowsError(
+            try CustomDirValidator.validateLocalDirectory(
+                linkedChildURL,
+                existingConfigs: [],
+                homeURL: workspace.homeURL,
+                fileManager: fileManager
+            )
+        ) { error in
+            XCTAssertEqual(error as? CustomDirValidationError, .localIsSymlink)
+        }
+    }
+
+    func testLocalOpenPanelGuardRejectsSymlinkDirectoryBeforeNavigation() throws {
+        let workspace = try makeWorkspace()
+        defer { cleanupWorkspace(workspace.rootURL) }
+
+        let realURL = workspace.rootURL.appendingPathComponent("RealPanelTarget")
+        let linkURL = workspace.homeURL.appendingPathComponent("panel-linked")
+        try createDirectoryWithPayload(at: realURL)
+        try fileManager.createSymbolicLink(at: linkURL, withDestinationURL: realURL)
+
+        let guardrail = CustomDirLocalOpenPanelGuard(
+            homeURL: workspace.homeURL,
+            existingConfigs: [],
+            fileManager: fileManager
+        )
+
+        XCTAssertFalse(guardrail.shouldEnable(linkURL))
+        XCTAssertEqual(guardrail.validationError(for: linkURL) as? CustomDirValidationError, .localIsSymlink)
+    }
+
+    func testValidatorRejectsNestedManagedLocalDirectories() throws {
+        let workspace = try makeWorkspace()
+        defer { cleanupWorkspace(workspace.rootURL) }
+
+        let parentURL = workspace.homeURL.appendingPathComponent("aaa")
+        let childURL = parentURL.appendingPathComponent("bbb")
+        try fileManager.createDirectory(at: childURL, withIntermediateDirectories: true)
+
+        let childConfig = CustomDirConfig(localPath: childURL.path, externalBasePath: workspace.externalBaseURL.path)
+        XCTAssertThrowsError(
+            try CustomDirValidator.validateLocalDirectory(
+                parentURL,
+                existingConfigs: [childConfig],
+                homeURL: workspace.homeURL,
+                fileManager: fileManager
+            )
+        ) { error in
+            XCTAssertEqual(error as? CustomDirValidationError, .localOverlapsManagedDirectory)
+        }
+
+        let parentConfig = CustomDirConfig(localPath: parentURL.path, externalBasePath: workspace.externalBaseURL.path)
+        XCTAssertThrowsError(
+            try CustomDirValidator.validateLocalDirectory(
+                childURL,
+                existingConfigs: [parentConfig],
+                homeURL: workspace.homeURL,
+                fileManager: fileManager
+            )
+        ) { error in
+            XCTAssertEqual(error as? CustomDirValidationError, .localOverlapsManagedDirectory)
+        }
+    }
+
+    func testValidatorRejectsExternalBaseInsideCurrentUserHome() throws {
+        let workspace = try makeWorkspace()
+        defer { cleanupWorkspace(workspace.rootURL) }
+
+        let localURL = workspace.homeURL.appendingPathComponent("develop")
+        let externalBaseURL = workspace.homeURL.appendingPathComponent("ExternalInHome")
+        try createDirectoryWithPayload(at: localURL)
+        try fileManager.createDirectory(at: externalBaseURL, withIntermediateDirectories: true)
+
+        XCTAssertThrowsError(
+            try CustomDirValidator.validate(
+                localURL: localURL,
+                externalBaseURL: externalBaseURL,
+                existingConfigs: [],
+                homeURL: workspace.homeURL,
+                fileManager: fileManager
+            )
+        ) { error in
+            XCTAssertEqual(error as? CustomDirValidationError, .externalInsideHome)
+        }
+    }
+
+    func testValidationErrorsHaveSpecificUserFacingMessages() {
+        LanguageManager.shared.language = "zh-Hans"
+        defer { LanguageManager.shared.language = "system" }
+
+        XCTAssertEqual(
+            CustomDirValidationError.localOutsideHome.errorDescription,
+            "本地目录必须位于当前用户目录下"
+        )
+        XCTAssertEqual(
+            CustomDirValidationError.localIsHome.errorDescription,
+            "不能迁移整个用户目录"
+        )
+        XCTAssertEqual(
+            CustomDirValidationError.localIsSymlink.errorDescription,
+            "不能迁移软链接目录，请选择真实文件夹"
+        )
+        XCTAssertEqual(
+            CustomDirValidationError.localOverlapsManagedDirectory.errorDescription,
+            "该目录与已管理目录存在包含关系"
+        )
+        XCTAssertEqual(
+            CustomDirValidationError.externalInsideHome.errorDescription,
+            "外部目标不能位于当前用户目录内"
+        )
+        XCTAssertEqual(
+            CustomDirValidationError.externalOverlapsManagedDirectory.errorDescription,
+            "外部目标与已管理目录存在包含关系"
+        )
+    }
+
+    private func makeWorkspace() throws -> (rootURL: URL, homeURL: URL, externalBaseURL: URL) {
+        let rootURL = fileManager.temporaryDirectory.appendingPathComponent("CustomDirScannerTests-\(UUID().uuidString)")
+        let homeURL = rootURL.appendingPathComponent("Home")
+        let externalBaseURL = rootURL.appendingPathComponent("External")
+
+        try fileManager.createDirectory(at: homeURL, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: externalBaseURL, withIntermediateDirectories: true)
+
+        return (rootURL, homeURL, externalBaseURL)
+    }
+
+    private func cleanupWorkspace(_ rootURL: URL) {
+        try? fileManager.removeItem(at: rootURL)
+    }
+
+    private func createDirectoryWithPayload(at directoryURL: URL) throws {
+        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        try "payload".write(
+            to: directoryURL.appendingPathComponent("payload.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+}

--- a/AppPortsTests/DataDirMoverTests.swift
+++ b/AppPortsTests/DataDirMoverTests.swift
@@ -298,6 +298,27 @@ final class DataDirMoverTests: XCTestCase {
         XCTAssertTrue(fileManager.fileExists(atPath: markerURL(for: normalizedExternalURL).path))
     }
 
+    func testDeleteLinkRemovesLocalSymlinkAndKeepsExternalDirectory() async throws {
+        let workspace = try makeWorkspace()
+        defer { cleanupWorkspace(workspace.rootURL) }
+
+        let localDataURL = workspace.homeURL
+            .appendingPathComponent("Projects/develop")
+        let externalDataURL = workspace.externalRootURL
+            .appendingPathComponent("Projects/develop")
+
+        try createDirectoryWithPayload(at: externalDataURL, payload: "external-source")
+
+        let mover = DataDirMover(homeDir: workspace.homeURL)
+        try await mover.createLink(localPath: localDataURL, externalPath: externalDataURL)
+
+        try await mover.deleteLink(localPath: localDataURL)
+
+        XCTAssertFalse(fileManager.fileExists(atPath: localDataURL.path))
+        XCTAssertEqual(try String(contentsOf: externalDataURL.appendingPathComponent("payload.txt")), "external-source")
+        XCTAssertTrue(fileManager.fileExists(atPath: markerURL(for: externalDataURL).path))
+    }
+
     func testMigrateRejectsGroupContainerRootDirectory() async throws {
         let workspace = try makeWorkspace()
         defer { cleanupWorkspace(workspace.rootURL) }

--- a/AppPortsTests/DataDirMoverTests.swift
+++ b/AppPortsTests/DataDirMoverTests.swift
@@ -101,7 +101,39 @@ final class DataDirMoverTests: XCTestCase {
 
         try assertRealDirectory(localDataURL)
         XCTAssertEqual(try String(contentsOf: localDataURL.appendingPathComponent("payload.txt")), "rollback-safe")
-        XCTAssertFalse(fileManager.fileExists(atPath: externalDataURL.path))
+        try assertRealDirectory(externalDataURL)
+        XCTAssertEqual(try String(contentsOf: externalDataURL.appendingPathComponent("payload.txt")), "rollback-safe")
+    }
+
+    func testMigrateKeepsExternalCopyWhenLocalBackupCleanupFails() async throws {
+        let workspace = try makeWorkspace()
+        defer { cleanupWorkspace(workspace.rootURL) }
+
+        let localDataURL = workspace.homeURL
+            .appendingPathComponent("Library/Caches/com.example.backup-cleanup")
+        let externalBaseURL = workspace.externalRootURL
+            .appendingPathComponent("Library/Caches")
+        let externalDataURL = externalBaseURL.appendingPathComponent(localDataURL.lastPathComponent)
+
+        try createDirectoryWithPayload(at: localDataURL, payload: "backup-cleanup-safe")
+
+        let item = DataDirItem(
+            name: "BackupCleanup",
+            path: localDataURL,
+            type: .caches,
+            priority: .optional,
+            description: "Backup cleanup failure fixture",
+            isMigratable: true
+        )
+
+        let mover = DataDirMover(homeDir: workspace.homeURL, failSourceBackupCleanup: true)
+        try await mover.migrate(item: item, to: externalBaseURL, progressHandler: nil)
+
+        try assertSymlink(localDataURL, pointsTo: externalDataURL)
+        XCTAssertEqual(try String(contentsOf: externalDataURL.appendingPathComponent("payload.txt")), "backup-cleanup-safe")
+
+        let parentContents = try fileManager.contentsOfDirectory(atPath: localDataURL.deletingLastPathComponent().path)
+        XCTAssertTrue(parentContents.contains { $0.contains(".appports-migration-backup-") })
     }
 
     func testMigrateRemovesPartialExternalDirectoryWhenCopyFails() async throws {


### PR DESCRIPTION
## Summary
- add a custom directory migration tab for migrating arbitrary user folders to external storage
- preserve user data during directory migration rollback by renaming the local source to a hidden safety backup before creating the symlink
- keep the external copy when symlink creation or backup cleanup fails, and update migration progress wording

## Verification
- xcodebuild test -scheme "AppPorts" -configuration Debug -destination 'platform=macOS' -only-testing:"AppPortsTests/DataDirMoverTests" -only-testing:"AppPortsTests/LocalizationAuditTests" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/AppPortsCodexDataLossVerify
- xcodebuild clean build -scheme "AppPorts" -configuration Release -destination 'platform=macOS' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/AppPortsCodexDataLossBuildFresh
